### PR TITLE
Propagate task errors

### DIFF
--- a/benches/compute_dag_bench.rs
+++ b/benches/compute_dag_bench.rs
@@ -24,7 +24,7 @@ fn compute_dag(tasks: Vec<DefaultTask>) {
     env.set("base", 2usize);
     dag.set_env(env);
 
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
     // Get execution result.
     let _res = dag.get_result::<usize>().unwrap();
 }

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -83,7 +83,7 @@ fn main() {
     env.set("base", 2usize);
     dag.set_env(env);
     // Start executing this dag
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
     // Get execution result.
     let res = dag.get_result::<usize>().unwrap();
     println!("The result is {}.", res);

--- a/examples/custom_log.rs
+++ b/examples/custom_log.rs
@@ -14,5 +14,5 @@ fn main() {
     let _ = SimpleLogger::init(LevelFilter::Info, Config::default());
 
     let mut dag = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
 }

--- a/examples/engine.rs
+++ b/examples/engine.rs
@@ -76,7 +76,7 @@ fn main() {
     // Add dag3 to engine.
     engine.append_dag("graph3", dag3);
     // Execute dag in order, the order should be dag1, dag2, dag3.
-    assert_eq!(engine.run_sequential(), vec![true, true, true]);
+    assert!(engine.run_sequential().is_ok());
     // Get the execution results of dag1 and dag2.
     assert_eq!(
         engine.get_dag_result::<usize>("graph1").unwrap().as_ref(),

--- a/examples/yaml_dag.rs
+++ b/examples/yaml_dag.rs
@@ -10,11 +10,11 @@ use std::collections::HashMap;
 fn main() {
     env_logger::init();
     let mut job = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
 
     let content = load_file("tests/config/correct.yaml").unwrap();
     let mut job = Dag::with_yaml_str(&content, HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
     let out = job.get_results::<Content>();
     for (k, v) in out {
         println!("{k} {:#?}", v.unwrap().get::<(Vec<String>, Vec<String>)>());

--- a/src/bin/dagrs.rs
+++ b/src/bin/dagrs.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let yaml_path = args.yaml;
     let mut dag = Dag::with_yaml(yaml_path.as_str(), HashMap::new()).unwrap();
-    assert!(dag.start().unwrap());
+    assert!(dag.start().is_ok());
 }
 
 fn init_logger(args: &Args) {

--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -89,6 +89,17 @@ impl Dag {
         }
     }
 
+    /// Reset the graph state but keep the tasks.
+    pub fn reset(&mut self) {
+        self.rely_graph = Graph::new();
+        self.execute_states = HashMap::new();
+        self.env = Arc::new(EnvVar::new());
+        self.can_continue = Arc::new(AtomicBool::new(true));
+        self.exe_sequence = Vec::new();
+        self.keep_going = false;
+        self.keep_going_errored = Arc::new(AtomicBool::new(false));
+    }
+
     /// Create a dag by adding a series of tasks.
     pub fn with_tasks(tasks: Vec<impl Task + 'static>) -> Dag {
         let mut dag = Dag::new();

--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -43,7 +43,7 @@ use tokio::task::JoinHandle;
 ///     Output::new(1)
 /// });
 /// let mut dag=Dag::with_tasks(vec![task]);
-/// assert!(dag.start().unwrap())
+/// assert!(dag.start().is_ok())
 ///
 /// ```
 #[derive(Debug)]
@@ -248,23 +248,24 @@ impl Dag {
     }
 
     /// This function is used for the execution of a single dag.
-    pub fn start(&mut self) -> Result<bool, DagError> {
+    pub fn start(&mut self) -> Result<(), DagError> {
         // If the current continuable state is false, the task will start failing.
         if self.can_continue.load(Ordering::Acquire) {
             self.init().map_or_else(Err, |_| {
-                Ok(tokio::runtime::Runtime::new()
+                tokio::runtime::Runtime::new()
                     .unwrap()
-                    .block_on(async { self.run().await }))
+                    .block_on(async { self.run().await })
             })
         } else {
-            Ok(false)
+            // TODO: Change this error
+            Err(DagError::EmptyJob)
         }
     }
 
     /// Execute tasks sequentially according to the execution sequence given by
     /// topological sorting, and cancel the execution of subsequent tasks if an
     /// error is encountered during task execution.
-    pub(crate) async fn run(&self) -> bool {
+    pub(crate) async fn run(&self) -> Result<(), DagError> {
         debug!("[Start]{} -> [End]", {
             self.exe_sequence
                 .iter()
@@ -284,8 +285,11 @@ impl Dag {
         for (tid, handle) in handles {
             match handle.await {
                 Ok(succeed) => {
-                    if !succeed {
+                    if succeed.is_err() {
                         self.handle_error(tid);
+                        if let Err(DagError::TaskError(_, _)) = succeed {
+                            return succeed;
+                        }
                     }
                 }
                 Err(err) => {
@@ -294,20 +298,29 @@ impl Dag {
                 }
             }
         }
-
         if self.keep_going {
             // when keep_going is true, the task will continue to execute as much as possible.
             // So, the success is evaluated by keep_going_errored.
-            !self.keep_going_errored.load(Ordering::Relaxed)
+            if !self.keep_going_errored.load(Ordering::Relaxed) {
+                Ok(())
+            } else {
+                Err(DagError::EmptyJob)
+            }
         } else {
-            self.can_continue
+            if self
+                .can_continue
                 .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
+            {
+                Ok(())
+            } else {
+                Err(DagError::EmptyJob)
+            }
         }
     }
 
     /// Execute a given task asynchronously.
-    fn execute_task(&self, task: &dyn Task) -> JoinHandle<bool> {
+    fn execute_task(&self, task: &dyn Task) -> JoinHandle<Result<(), DagError>> {
         let env = self.env.clone();
         let task_id = task.id();
         let task_name = task.name().to_string();
@@ -330,7 +343,7 @@ impl Dag {
                 // the continuation flag is set to false, if it is set to false, cancel the specific
                 // execution logic of the task and return immediately.
                 if !can_continue.load(Ordering::Acquire) || !wait_for.success() {
-                    return true;
+                    return Ok(());
                 }
                 if let Some(content) = wait_for.get_output() {
                     inputs.push(content);
@@ -342,24 +355,24 @@ impl Dag {
                 .map_or_else(
                     |_| {
                         error!("Execution failed [name: {}, id: {}]", task_name, task_id);
-                        false
+                        // TODO: Change this error
+                        Err(DagError::EmptyJob)
                     },
                     |out| {
                         // Store execution results
                         if out.is_err() {
+                            let error = out.get_err().unwrap_or("".to_string());
                             error!(
                                 "Execution failed [name: {}, id: {}]\nerr: {}",
-                                task_name,
-                                task_id,
-                                out.get_err().unwrap_or("".to_string())
+                                task_name, task_id, error
                             );
-                            false
+                            Err(DagError::TaskError(task_id, error))
                         } else {
                             execute_state.set_output(out);
                             execute_state.exe_success();
                             execute_state.semaphore().add_permits(task_out_degree);
                             debug!("Execution succeed [name: {}, id: {}]", task_name, task_id);
-                            true
+                            Ok(())
                         }
                     },
                 )

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,7 +16,6 @@ use thiserror::Error;
 mod dag;
 mod graph;
 
-use crate::ParseError;
 use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::Runtime;
 
@@ -37,7 +36,7 @@ pub struct Engine {
 pub enum DagError {
     /// Yaml file parsing error.
     #[error("Parsing error: {0}")]
-    ParserError(ParseError),
+    ParserError(String),
     /// Task dependency error.
     #[error("Task[{0}] dependency task not exist.")]
     RelyTaskIllegal(String),
@@ -47,6 +46,9 @@ pub enum DagError {
     /// There are no tasks in the job.
     #[error("There are no tasks in the job.")]
     EmptyJob,
+    /// Task error
+    #[error("Task with ID {0} errored: {1}")]
+    TaskError(usize, String),
 }
 
 impl Engine {
@@ -69,24 +71,22 @@ impl Engine {
 
     /// Given a Dag name, execute this Dag.
     /// Returns true if the given Dag executes successfully, otherwise false.
-    pub fn run_dag(&mut self, name: &str) -> bool {
+    pub fn run_dag(&mut self, name: &str) -> Result<(), DagError> {
         if let Some(dag) = self.dags.get(name) {
             self.runtime.block_on(dag.run())
         } else {
             error!("No job named '{}'", name);
-            false
+            Err(DagError::EmptyJob)
         }
     }
 
     /// Execute all the Dags in the Engine in sequence according to the order numbers of the Dags in
-    /// the sequence from small to large. The return value is the execution status of all tasks.
-    pub fn run_sequential(&mut self) -> Vec<bool> {
-        let mut res = Vec::with_capacity(self.sequence.len());
+    pub fn run_sequential(&mut self) -> Result<(), DagError> {
         for seq in 1..self.sequence.len() + 1 {
             let name = self.sequence.get(&seq).unwrap().clone();
-            res.push(self.run_dag(name.as_str()));
+            self.run_dag(name.as_str())?;
         }
-        res
+        Ok(())
     }
 
     /// Given the name of the Dag, get the execution result of the specified Dag.
@@ -102,11 +102,5 @@ impl Default for Engine {
             runtime: Runtime::new().unwrap(),
             sequence: HashMap::new(),
         }
-    }
-}
-
-impl From<ParseError> for DagError {
-    fn from(value: ParseError) -> Self {
-        Self::ParserError(value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use engine::{Dag, DagError, Engine};
 pub use task::{
     alloc_id, Action, CommandAction, Complex, DefaultTask, Input, Output, Simple, Task,
 };
-pub use utils::{EnvVar, ParseError, Parser};
+pub use utils::{EnvVar, Parser};
 #[cfg(feature = "yaml")]
 pub use yaml::{FileContentError, FileNotFound, YamlParser, YamlTask, YamlTaskError};
 

--- a/src/task/default_task.rs
+++ b/src/task/default_task.rs
@@ -119,6 +119,11 @@ impl DefaultTask {
         }
     }
 
+    /// Overwrite the allocated ID.
+    pub fn set_id(&mut self, id: usize) {
+        self.id = id;
+    }
+
     /// Give the task a name.
     pub fn set_name(&mut self, name: &str) {
         self.name = name.to_string();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,4 +8,4 @@ pub mod file;
 mod parser;
 
 pub use self::env::EnvVar;
-pub use self::parser::{ParseError, Parser};
+pub use self::parser::Parser;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -1,7 +1,6 @@
 //! Task configuration file parser interface
-use thiserror::Error;
 
-use crate::{task::Task, Action};
+use crate::{task::Task, Action, DagError};
 use std::collections::HashMap;
 
 /// Generic parser traits. If users want to customize the configuration file parser, they must implement this trait.
@@ -24,31 +23,11 @@ pub trait Parser {
         &self,
         file: &str,
         specific_actions: HashMap<String, Action>,
-    ) -> Result<Vec<Box<dyn Task>>, ParseError>;
+    ) -> Result<Vec<Box<dyn Task>>, DagError>;
 
     fn parse_tasks_from_str(
         &self,
         content: &str,
         specific_actions: HashMap<String, Action>,
-    ) -> Result<Vec<Box<dyn Task>>, ParseError>;
-}
-
-/// Errors that may occur during configuration file parsing.
-/// This structure stores error information. Users need to customize error types and implement conversion
-/// from custom error types to [`ParseError`].
-/// By default, a conversion from `String` type to [`ParseError`] is provided.
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct ParseError(pub String);
-
-impl From<String> for ParseError {
-    fn from(value: String) -> Self {
-        ParseError(value)
-    }
-}
-
-impl From<std::io::Error> for ParseError {
-    fn from(value: std::io::Error) -> Self {
-        ParseError(value.to_string())
-    }
+    ) -> Result<Vec<Box<dyn Task>>, DagError>;
 }

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -55,12 +55,11 @@
 mod yaml_parser;
 mod yaml_task;
 
+use crate::DagError;
 use thiserror::Error;
 
 pub use self::yaml_parser::YamlParser;
 pub use self::yaml_task::YamlTask;
-
-use crate::ParseError;
 
 /// Errors about task configuration items.
 #[derive(Debug, Error)]
@@ -95,20 +94,20 @@ pub enum FileContentError {
 #[error("File not found. [{0}]")]
 pub struct FileNotFound(pub std::io::Error);
 
-impl From<YamlTaskError> for ParseError {
+impl From<YamlTaskError> for DagError {
     fn from(value: YamlTaskError) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string())
     }
 }
 
-impl From<FileContentError> for ParseError {
+impl From<FileContentError> for DagError {
     fn from(value: FileContentError) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string())
     }
 }
 
-impl From<FileNotFound> for ParseError {
+impl From<FileNotFound> for DagError {
     fn from(value: FileNotFound) -> Self {
-        value.to_string().into()
+        DagError::ParserError(value.to_string().into())
     }
 }

--- a/tests/dag_job_test.rs
+++ b/tests/dag_job_test.rs
@@ -7,7 +7,7 @@ use dagrs::{Complex, Dag, DagError, DefaultTask, EnvVar, Input, Output};
 #[test]
 fn yaml_task_correct_execute() {
     let mut job = Dag::with_yaml("tests/config/correct.yaml", HashMap::new()).unwrap();
-    assert!(job.start().unwrap());
+    assert!(job.start().is_ok());
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn yaml_task_failed_execute() {
     let res = Dag::with_yaml("tests/config/script_run_failed.yaml", HashMap::new())
         .unwrap()
         .start();
-    assert!(!res.unwrap());
+    assert!(!res.is_ok());
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn test_dag(keep_going: bool, num_some_output: Option<usize>) {
     }
 
     job.set_env(env);
-    assert!(!job.start().unwrap()); // reports a failure
+    assert!(!job.start().is_ok()); // reports a failure
 
     // but the results for independent tasks are still available
     let output = job.get_results::<usize>();

--- a/tests/yaml_parser_test.rs
+++ b/tests/yaml_parser_test.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use dagrs::{ParseError, Parser, Task, YamlParser};
+use dagrs::{DagError, Parser, Task, YamlParser};
 
 #[test]
 fn file_not_found_test() {
-    let no_such_file: Result<Vec<Box<dyn Task>>, ParseError> =
+    let no_such_file: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("./no_such_file.yaml", HashMap::new());
     // let err = no_such_file.unwrap_err().to_string();
     // println!("{err}");
@@ -13,7 +13,7 @@ fn file_not_found_test() {
 
 #[test]
 fn illegal_yaml_content() {
-    let illegal_content: Result<Vec<Box<dyn Task>>, ParseError> =
+    let illegal_content: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/illegal_content.yaml", HashMap::new());
     // let err = illegal_content.unwrap_err().to_string();
     // println!("{err}");
@@ -22,7 +22,7 @@ fn illegal_yaml_content() {
 
 #[test]
 fn empty_content() {
-    let empty_content: Result<Vec<Box<dyn Task>>, ParseError> =
+    let empty_content: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/empty_file.yaml", HashMap::new());
     // let err = empty_content.unwrap_err().to_string();
     // println!("{err}");
@@ -31,7 +31,7 @@ fn empty_content() {
 
 #[test]
 fn yaml_no_start_with_dagrs() {
-    let forget_dagrs: Result<Vec<Box<dyn Task>>, ParseError> =
+    let forget_dagrs: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_start_with_dagrs.yaml", HashMap::new());
     // let err = forget_dagrs.unwrap_err().to_string();
     // println!("{err}");
@@ -40,7 +40,7 @@ fn yaml_no_start_with_dagrs() {
 
 #[test]
 fn yaml_task_no_name() {
-    let no_task_name: Result<Vec<Box<dyn Task>>, ParseError> =
+    let no_task_name: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_task_name.yaml", HashMap::new());
     // let err = no_task_name.unwrap_err().to_string();
     // println!("{err}");
@@ -49,7 +49,7 @@ fn yaml_task_no_name() {
 
 #[test]
 fn yaml_task_not_found_precursor() {
-    let not_found_pre: Result<Vec<Box<dyn Task>>, ParseError> =
+    let not_found_pre: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/precursor_not_found.yaml", HashMap::new());
     // let err = not_found_pre.unwrap_err().to_string();
     // println!("{err}");
@@ -58,7 +58,7 @@ fn yaml_task_not_found_precursor() {
 
 #[test]
 fn yaml_task_no_script_config() {
-    let script: Result<Vec<Box<dyn Task>>, ParseError> =
+    let script: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/no_script.yaml", HashMap::new());
     // let err = script.unwrap_err().to_string();
     // println!("{err}");
@@ -67,7 +67,7 @@ fn yaml_task_no_script_config() {
 
 #[test]
 fn correct_parse() {
-    let tasks: Result<Vec<Box<dyn Task>>, ParseError> =
+    let tasks: Result<Vec<Box<dyn Task>>, DagError> =
         YamlParser.parse_tasks("tests/config/correct.yaml", HashMap::new());
     assert!(tasks.is_ok());
 }


### PR DESCRIPTION
This merges @tomgroenwoldt's changes for propagating task errors up to the caller.