### PR TITLE
Make the crate executor agnostic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ keywords = ["DAG", "task", "async", "parallel", "concurrent"]
 members = ["derive", "."]
 
 [dependencies]
+async-lock = "3.4.0"
+futures-concurrency = { version = "7.6.3", default-features = false, features = ["alloc"] }
 yaml-rust = { version = "0.4.5", optional = true }
 bimap = "0.6.1"
 clap = { version = "4.2.2", features = ["derive"] }
-tokio = { version = "1.28", features = ["rt", "sync", "rt-multi-thread"] }
 derive = { path = "derive", version = "0.3.0", optional = true }
 thiserror = "1.0.50"
 log = "0.4"
@@ -25,6 +26,7 @@ env_logger = "0.10.1"
 [dev-dependencies]
 simplelog = "0.12"
 criterion = { version = "0.5.1", features = ["html_reports"] }
+futures-lite = "2.6.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.13.0" }

--- a/examples/compute_dag.rs
+++ b/examples/compute_dag.rs
@@ -83,7 +83,7 @@ fn main() {
     env.set("base", 2usize);
     dag.set_env(env);
     // Start executing this dag
-    assert!(dag.start().is_ok());
+    assert!(futures_lite::future::block_on(dag.start()).is_ok());
     // Get execution result.
     let res = dag.get_result::<usize>().unwrap();
     println!("The result is {}.", res);

--- a/examples/custom_parser_and_task.rs
+++ b/examples/custom_parser_and_task.rs
@@ -150,5 +150,5 @@ fn main() {
     let file = "tests/config/custom_file_task.txt";
     let mut dag =
         Dag::with_config_file_and_parser(file, Box::new(ConfigParser), HashMap::new()).unwrap();
-    assert!(dag.start().is_ok());
+    assert!(futures_lite::future::block_on(dag.start()).is_ok());
 }

--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -65,10 +65,6 @@ pub struct Dag {
     /// when all tasks in the dag are executed, the flag will also be set to false, indicating that
     /// the task cannot be run repeatedly.
     can_continue: Arc<AtomicBool>,
-    /// A flag that indicates whether the task should continue to execute as much as possible.
-    keep_going: bool,
-    /// When `keep_going` is true, and an error occurs during the execution of a task, this flag will be set to true.
-    keep_going_errored: Arc<AtomicBool>,
     /// The execution sequence of tasks.
     exe_sequence: Vec<usize>,
 }
@@ -84,8 +80,6 @@ impl Dag {
             env: Arc::new(EnvVar::new()),
             can_continue: Arc::new(AtomicBool::new(true)),
             exe_sequence: Vec::new(),
-            keep_going: false,
-            keep_going_errored: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -96,8 +90,6 @@ impl Dag {
         self.env = Arc::new(EnvVar::new());
         self.can_continue = Arc::new(AtomicBool::new(true));
         self.exe_sequence = Vec::new();
-        self.keep_going = false;
-        self.keep_going_errored = Arc::new(AtomicBool::new(false));
     }
 
     /// Create a dag by adding a series of tasks.
@@ -159,14 +151,6 @@ impl Dag {
         specific_actions: HashMap<String, Action>,
     ) -> Result<Dag, DagError> {
         Dag::read_tasks_from_str(content, parser, specific_actions)
-    }
-
-    /// Set the flag that indicates whether the task should continue to execute as much as possible.
-    /// This means that even if an error occurs during the execution of a task, the subsequent independent tasks
-    /// will continue to execute unless a dependency error occurs.
-    pub fn keep_going(mut self) -> Dag {
-        self.keep_going = true;
-        self
     }
 
     /// Parse the content of the configuration file into a series of tasks and generate a dag.
@@ -307,15 +291,8 @@ impl Dag {
                 }
             }
         }
-        if self.keep_going {
-            // when keep_going is true, the task will continue to execute as much as possible.
-            // So, the success is evaluated by keep_going_errored.
-            if !self.keep_going_errored.load(Ordering::Relaxed) {
-                Ok(())
-            } else {
-                Err(DagError::EmptyJob)
-            }
-        } else if self
+
+        if self
             .can_continue
             .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
@@ -386,25 +363,10 @@ impl Dag {
         })
     }
 
-    /// error handling.
-    /// When a task execution error occurs, the error handling logic is:
-    /// First, set the continuation status to false, and then release the semaphore of the
-    /// error task and the tasks after the error task, so that subsequent tasks can quickly
-    /// know that some tasks have errors and cannot continue to execute.
-    /// After that, the follow-up task finds that the flag that can continue to execute is set
-    /// to false, and the specific behavior of executing the task will be cancelled.
-    fn handle_error(&self, error_task_id: usize) {
-        if self.keep_going {
-            self.handle_errored_keep_going(error_task_id);
-        } else {
-            self.handle_errored_stopping(error_task_id);
-        }
-    }
-
     /// When the keep_going flag is set to false, the error handling logic is:
     /// - Set the continuation status to false
     /// - Adding permits for all the subsequent tasks
-    fn handle_errored_stopping(&self, error_task_id: usize) {
+    fn handle_error(&self, error_task_id: usize) {
         if self
             .can_continue
             .compare_exchange(true, false, Ordering::SeqCst, Ordering::Relaxed)
@@ -423,24 +385,6 @@ impl Dag {
         // Add permits for all the subsequent tasks
         for tid in self.exe_sequence.iter().skip(index) {
             self.handle_errored_successor(tid, false);
-        }
-    }
-
-    /// When the keep_going flag is set to true, the error handling logic is:
-    /// - Set the keep_going_errored flag to true
-    /// - Adding permits for all tasks that rely on the error task
-    /// - Setting them as failed
-    fn handle_errored_keep_going(&self, error_task_id: usize) {
-        self.keep_going_errored.store(true, Ordering::SeqCst);
-
-        // Add permits for the tasks that rely on the error task
-        for successor in self
-            .rely_graph
-            .get_node_successors(&error_task_id)
-            .into_iter()
-        {
-            let tid = self.rely_graph.find_id_by_index(successor).unwrap();
-            self.handle_errored_successor(&tid, true);
         }
     }
 

--- a/src/engine/dag.rs
+++ b/src/engine/dag.rs
@@ -4,16 +4,17 @@ use crate::{
     utils::EnvVar,
     Action, Parser,
 };
+use futures_concurrency::future::TryJoin;
 use log::{debug, error};
 use std::{
     collections::HashMap,
+    future::Future,
     panic::{self, AssertUnwindSafe},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
 };
-use tokio::task::JoinHandle;
 
 /// [`Dag`] is dagrs's main body.
 ///
@@ -43,7 +44,7 @@ use tokio::task::JoinHandle;
 ///     Output::new(1)
 /// });
 /// let mut dag=Dag::with_tasks(vec![task]);
-/// assert!(dag.start().is_ok())
+/// assert!(futures_lite::future::block_on(dag.start()).is_ok());
 ///
 /// ```
 #[derive(Debug)]
@@ -241,18 +242,15 @@ impl Dag {
     }
 
     /// This function is used for the execution of a single dag.
-    pub fn start(&mut self) -> Result<(), DagError> {
+    pub async fn start(&mut self) -> Result<(), DagError> {
         // If the current continuable state is false, the task will start failing.
-        if self.can_continue.load(Ordering::Acquire) {
-            self.init().map_or_else(Err, |_| {
-                tokio::runtime::Runtime::new()
-                    .unwrap()
-                    .block_on(async { self.run().await })
-            })
-        } else {
+        if !self.can_continue.load(Ordering::Acquire) {
             // TODO: Change this error
-            Err(DagError::EmptyJob)
+            return Err(DagError::EmptyJob);
         }
+
+        self.init()?;
+        self.run().await
     }
 
     /// Execute tasks sequentially according to the execution sequence given by
@@ -270,25 +268,15 @@ impl Dag {
         let handles = self
             .exe_sequence
             .iter()
-            .map(|id| (*id, self.execute_task(self.tasks[id].as_ref())))
-            .collect::<Vec<_>>();
+            .map(|id| self.execute_task(self.tasks[id].as_ref()))
+            .collect::<Vec<_>>()
+            .try_join()
+            .await;
 
-        // Wait for the status of each task to execute. If there is an error in the execution of a task,
-        // the engine will fail to execute and give up executing tasks that have not yet been executed.
-        for (tid, handle) in handles {
-            match handle.await {
-                Ok(succeed) => {
-                    if succeed.is_err() {
-                        self.handle_error(tid);
-                        if let Err(DagError::TaskError(_, _)) = succeed {
-                            return succeed;
-                        }
-                    }
-                }
-                Err(err) => {
-                    error!("Task execution encountered an unexpected error! {}", err);
-                    self.handle_error(tid);
-                }
+        if let Err((task_id, err)) = handles {
+            self.handle_error(task_id);
+            if let DagError::TaskError(_, _) = err {
+                return Err(err);
             }
         }
 
@@ -304,7 +292,7 @@ impl Dag {
     }
 
     /// Execute a given task asynchronously.
-    fn execute_task(&self, task: &dyn Task) -> JoinHandle<Result<(), DagError>> {
+    fn execute_task(&self, task: &dyn Task) -> impl Future<Output = Result<(), (usize, DagError)>> {
         let env = self.env.clone();
         let task_id = task.id();
         let task_name = task.name().to_string();
@@ -318,11 +306,11 @@ impl Dag {
         let action = task.action();
         let can_continue = self.can_continue.clone();
 
-        tokio::spawn(async move {
+        async move {
             // Wait for the execution result of the predecessor task
             let mut inputs = Vec::with_capacity(wait_for_input.len());
             for wait_for in wait_for_input {
-                wait_for.semaphore().acquire().await.unwrap().forget();
+                wait_for.semaphore().acquire().await.forget();
                 // When the task execution result of the predecessor can be obtained, judge whether
                 // the continuation flag is set to false, if it is set to false, cancel the specific
                 // execution logic of the task and return immediately.
@@ -340,7 +328,7 @@ impl Dag {
                     |_| {
                         error!("Execution failed [name: {}, id: {}]", task_name, task_id);
                         // TODO: Change this error
-                        Err(DagError::EmptyJob)
+                        Err((task_id, DagError::EmptyJob))
                     },
                     |out| {
                         // Store execution results
@@ -350,7 +338,7 @@ impl Dag {
                                 "Execution failed [name: {}, id: {}]\nerr: {}",
                                 task_name, task_id, error
                             );
-                            Err(DagError::TaskError(task_id, error))
+                            Err((task_id, DagError::TaskError(task_id, error)))
                         } else {
                             execute_state.set_output(out);
                             execute_state.exe_success();
@@ -360,7 +348,7 @@ impl Dag {
                         }
                     },
                 )
-        })
+        }
     }
 
     /// When the keep_going flag is set to false, the error handling logic is:

--- a/src/engine/graph.rs
+++ b/src/engine/graph.rs
@@ -138,46 +138,6 @@ impl Graph {
             None => 0,
         }
     }
-
-    /// Get all the successors of a node (direct or indirect).
-    /// This function will return a vector of indices of successors (including itself).
-    pub(crate) fn get_node_successors(&self, id: &usize) -> Vec<usize> {
-        match self.nodes.get_by_left(id) {
-            Some(index) => {
-                // initialize a vector to store successors with max possible size
-                let mut successors = Vec::with_capacity(self.adj[*index].len());
-
-                // create a visited array to avoid visiting a node more than once
-                let mut visited = vec![false; self.size];
-
-                // do BFS traversal starting from current node
-
-                // mark the current node as visited and enqueue it
-                visited[*index] = true;
-                successors.push(*index);
-
-                // the index of the queue
-                let mut i_queue = 0;
-
-                // while the queue is not empty
-                while i_queue < successors.len() {
-                    let v = successors[i_queue];
-
-                    for &index in self.adj[v].iter() {
-                        // if not visited, mark it as visited and collect it
-                        if !visited[index] {
-                            visited[index] = true;
-                            successors.push(index);
-                        }
-                    }
-                    i_queue += 1;
-                }
-                successors
-            }
-            // If node not found, return empty vector
-            None => Vec::new(),
-        }
-    }
 }
 
 impl Default for Graph {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -16,20 +16,6 @@ use thiserror::Error;
 mod dag;
 mod graph;
 
-use std::{collections::HashMap, sync::Arc};
-use tokio::runtime::Runtime;
-
-/// The Engine. Manage multiple Dags.
-pub struct Engine {
-    dags: HashMap<String, Dag>,
-    /// According to the order in which Dags are added to the Engine, assign a sequence number to each Dag.
-    /// Sequence numbers can be used to execute Dags sequentially.
-    sequence: HashMap<usize, String>,
-    /// A tokio runtime.
-    /// In order to save computer resources, multiple Dags share one runtime.
-    runtime: Runtime,
-}
-
 /// Errors that may be raised by building and running dag jobs.
 #[derive(Debug, Error)]
 /// A synthesis of all possible errors.
@@ -49,58 +35,4 @@ pub enum DagError {
     /// Task error
     #[error("Task with ID {0} errored: {1}")]
     TaskError(usize, String),
-}
-
-impl Engine {
-    /// Add a Dag to the Engine and assign a sequence number to the Dag.
-    /// It should be noted that different Dags should specify different names.
-    pub fn append_dag(&mut self, name: &str, mut dag: Dag) {
-        if !self.dags.contains_key(name) {
-            match dag.init() {
-                Ok(()) => {
-                    self.dags.insert(name.to_string(), dag);
-                    let len = self.sequence.len();
-                    self.sequence.insert(len + 1, name.to_string());
-                }
-                Err(err) => {
-                    error!("Some error occur: {}", err);
-                }
-            }
-        }
-    }
-
-    /// Given a Dag name, execute this Dag.
-    /// Returns true if the given Dag executes successfully, otherwise false.
-    pub fn run_dag(&mut self, name: &str) -> Result<(), DagError> {
-        if let Some(dag) = self.dags.get(name) {
-            self.runtime.block_on(dag.run())
-        } else {
-            error!("No job named '{}'", name);
-            Err(DagError::EmptyJob)
-        }
-    }
-
-    /// Execute all the Dags in the Engine in sequence according to the order numbers of the Dags in
-    pub fn run_sequential(&mut self) -> Result<(), DagError> {
-        for seq in 1..self.sequence.len() + 1 {
-            let name = self.sequence.get(&seq).unwrap().clone();
-            self.run_dag(name.as_str())?;
-        }
-        Ok(())
-    }
-
-    /// Given the name of the Dag, get the execution result of the specified Dag.
-    pub fn get_dag_result<T: Send + Sync + Clone + 'static>(&self, name: &str) -> Option<Arc<T>> {
-        self.dags.get(name).and_then(|dag| dag.get_result())
-    }
-}
-
-impl Default for Engine {
-    fn default() -> Self {
-        Self {
-            dags: HashMap::new(),
-            runtime: Runtime::new().unwrap(),
-            sequence: HashMap::new(),
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,12 @@ extern crate bimap;
 extern crate clap;
 #[cfg(feature = "derive")]
 extern crate derive;
-extern crate tokio;
 #[cfg(feature = "yaml")]
 extern crate yaml_rust;
 
 #[cfg(feature = "derive")]
 pub use derive::*;
-pub use engine::{Dag, DagError, Engine};
+pub use engine::{Dag, DagError};
 pub use task::{
     alloc_id, Action, CommandAction, Complex, DefaultTask, Input, Output, Simple, Task,
 };

--- a/src/task/state.rs
+++ b/src/task/state.rs
@@ -44,7 +44,7 @@ use std::{
     },
 };
 
-use tokio::sync::Semaphore;
+use async_lock::Semaphore;
 
 /// Container type to store task output.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Important to note is that this implementation doesn't spawn any new tasks which means that while it's concurrent there is therefore no parallelism possible.  We run this in a one-thread executor anyway and would not benefit from parallelism.